### PR TITLE
Revert ICU dependency temporarily to version that dotnet 3.1 can use

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -17,6 +17,19 @@ api = "0.8"
   pre-package = "./scripts/build.sh"
 
   [[metadata.dependencies]]
+    cpe = "cpe:2.3:a:icu-project:international_components_for_unicode:69.1:*:*:*:*:c\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\/c\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\+\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\+:*:*"
+    id = "icu"
+    licenses = ["BSD-3-Clause", "Unicode-TOU"]
+    name = "ICU"
+    purl = "pkg:generic/icu@69.1?checksum=4cba7b7acd1d3c42c44bb0c14be6637098c7faf2b330ce876bc5f3b915d09745&download_url=https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-src.tgz"
+    sha256 = "9c53e6a14b641d3ce966f0a8817e3805c254ec220c91aabdf0ad8d625ef3b282"
+    source = "https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-src.tgz"
+    source_sha256 = "4cba7b7acd1d3c42c44bb0c14be6637098c7faf2b330ce876bc5f3b915d09745"
+    stacks = ["io.buildpacks.stacks.bionic"]
+    uri = "https://deps.paketo.io/icu/icu_69.1_linux_noarch_bionic_9c53e6a1.tgz"
+    version = "69.1.0"
+
+  [[metadata.dependencies]]
     cpe = "cpe:2.3:a:icu-project:international_components_for_unicode:70.1:*:*:*:*:c\\\\/c\\\\+\\\\+:*:*"
     id = "icu"
     licenses = ["BSD-2-Clause", "BSD-3-Clause", "Unicode-TOU"]
@@ -28,19 +41,6 @@ api = "0.8"
     stacks = ["io.buildpacks.stacks.bionic"]
     uri = "https://deps.paketo.io/icu/icu_70.1_linux_noarch_bionic_bb0e9fde.tgz"
     version = "70.1.0"
-
-  [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:icu-project:international_components_for_unicode:71.1:*:*:*:*:c\\\\/c\\\\+\\\\+:*:*"
-    id = "icu"
-    licenses = ["BSD-2-Clause", "BSD-3-Clause", "ICU", "Unicode-TOU"]
-    name = "ICU"
-    purl = "pkg:generic/icu@71.1?checksum=67a7e6e51f61faf1306b6935333e13b2c48abd8da6d2f46ce6adca24b1e21ebf&download_url=https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-src.tgz"
-    sha256 = "a5c752fd6e8763655ca0c46e119987986708b2ff4ee68add49eeed6bfce16eb4"
-    source = "https://github.com/unicode-org/icu/releases/download/release-71-1/icu4c-71_1-src.tgz"
-    source_sha256 = "67a7e6e51f61faf1306b6935333e13b2c48abd8da6d2f46ce6adca24b1e21ebf"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://deps.paketo.io/icu/icu_71.1_linux_noarch_bionic_a5c752fd.tgz"
-    version = "71.1.0"
 
   [[metadata.dependency-constraints]]
     constraint = "*"


### PR DESCRIPTION
For context it appears that ICU 71.1 does not work with .Net 3.1 which is demonstrated in the [here](https://forum.manjaro.org/t/dotnet-3-1-builds-fail-after-icu-system-package-updated-to-71-1-1/114232/9) I would like to implement a more permanent solution after closing out the SBOM work.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
