### PR TITLE
Add Jammy stack to dependencies

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -25,7 +25,7 @@ api = "0.8"
     sha256 = "9c53e6a14b641d3ce966f0a8817e3805c254ec220c91aabdf0ad8d625ef3b282"
     source = "https://github.com/unicode-org/icu/releases/download/release-69-1/icu4c-69_1-src.tgz"
     source_sha256 = "4cba7b7acd1d3c42c44bb0c14be6637098c7faf2b330ce876bc5f3b915d09745"
-    stacks = ["io.buildpacks.stacks.bionic"]
+    stacks = ["io.buildpacks.stacks.bionic","io.buildpacks.stacks.jammy"]
     uri = "https://deps.paketo.io/icu/icu_69.1_linux_noarch_bionic_9c53e6a1.tgz"
     version = "69.1.0"
 
@@ -38,7 +38,7 @@ api = "0.8"
     sha256 = "bb0e9fde6a7130268f61f433aea746c2a7b72526e912d2c731f2655af620d31c"
     source = "https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-src.tgz"
     source_sha256 = "8d205428c17bf13bb535300669ed28b338a157b1c01ae66d31d0d3e2d47c3fd5"
-    stacks = ["io.buildpacks.stacks.bionic"]
+    stacks = ["io.buildpacks.stacks.bionic","io.buildpacks.stacks.jammy"]
     uri = "https://deps.paketo.io/icu/icu_70.1_linux_noarch_bionic_bb0e9fde.tgz"
     version = "70.1.0"
 
@@ -49,3 +49,5 @@ api = "0.8"
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
+[[stacks]]
+  id = "io.buildpacks.stacks.jammy"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The [Paketo Jammy Stacks RFC](https://github.com/paketo-buildpacks/rfcs/blob/ba9273ded6c65274276677b1ad5db5e61029060d/text/stacks/0004-jammy-jellyfish.md) has been accepted, and specifies that the Jammy Full and Base stacks will have the stack ID `io.buildpacks.stacks.jammy`.This PR adds the Jammy stack to the ICU dependencies.

A related [dep-server PR](https://github.com/paketo-buildpacks/dep-server/pull/181) will honor this change for new versions of .NET as they're added. Once this is approved, I'll also updated the existing `metadata.json` for the dependencies currently in the buildpack to reflect this change.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Will allow the .NET Core buildpack to run on Jammy.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).

