### PR TITLE
fix how retrieval is run

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,30 +16,6 @@ api = "0.8"
   include-files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml"]
   pre-package = "./scripts/build.sh"
 
-  [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:icu-project:international_components_for_unicode:70.1:*:*:*:*:c\\\\/c\\\\+\\\\+:*:*"
-    id = "icu"
-    licenses = ["BSD-2-Clause", "BSD-3-Clause", "Unicode-TOU"]
-    purl = "pkg:generic/icu@70.1?checksum=8d205428c17bf13bb535300669ed28b338a157b1c01ae66d31d0d3e2d47c3fd5&download_url=https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-src.tgz"
-    sha256 = "de4f152b204c89470f6efd09d5ec18a9474aff6ecc5065ef66d7320a224b15de"
-    source = "https://github.com/unicode-org/icu/releases/download/release-70-1/icu4c-70_1-src.tgz"
-    source_sha256 = "8d205428c17bf13bb535300669ed28b338a157b1c01ae66d31d0d3e2d47c3fd5"
-    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
-    uri = "https://deps.paketo.io/icu/icu_70.1_linux_noarch_bionic_de4f152b.tgz"
-    version = "70.1.0"
-
-  [[metadata.dependencies]]
-    cpe = "cpe:2.3:a:icu-project:international_components_for_unicode:72.1:*:*:*:*:c\\\\/c\\\\+\\\\+:*:*"
-    id = "icu"
-    licenses = ["BSD-2-Clause", "BSD-3-Clause", "ICU", "Unicode-TOU"]
-    purl = "pkg:generic/icu@72.1?checksum=a2d2d38217092a7ed56635e34467f92f976b370e20182ad325edea6681a71d68&download_url=https://github.com/unicode-org/icu/releases/download/release-72-1/icu4c-72_1-src.tgz"
-    sha256 = "72d0e9e72535c7b11eb4aa30af08475cd1ddf6c01412d29b2d51b80046ade1c9"
-    source = "https://github.com/unicode-org/icu/releases/download/release-72-1/icu4c-72_1-src.tgz"
-    source_sha256 = "a2d2d38217092a7ed56635e34467f92f976b370e20182ad325edea6681a71d68"
-    stacks = ["io.buildpacks.stacks.bionic", "io.buildpacks.stacks.jammy"]
-    uri = "https://deps.paketo.io/icu/icu_72.1_linux_noarch_bionic_72d0e9e7.tgz"
-    version = "72.1.0"
-
   [[metadata.dependency-constraints]]
     constraint = "70.*"
     id = "icu"

--- a/dependency/Makefile
+++ b/dependency/Makefile
@@ -1,7 +1,8 @@
 .PHONY: test retrieve
 
 retrieve:
-	@go run ./retrieval \
+	@cd retrieval; \
+	go run main.go \
 		--buildpack-toml-path "${buildpackTomlPath}" \
 		--output "${output}"
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Running dependency retrieval fails to run via `make` with the current set up. This change should hopefully fix that

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
